### PR TITLE
feat: only deploy camunda diagram when changed (CMC-1443)

### DIFF
--- a/bin/import-bpmn-diagram.sh
+++ b/bin/import-bpmn-diagram.sh
@@ -24,7 +24,8 @@ do
     ${CAMUNDA_BASE_URL:-http://localhost:9404}/engine-rest/deployment/create \
     -H "Accept: application/json" \
     -H "ServiceAuthorization: Bearer ${serviceToken}" \
-    -F "deployment-name=$(date +"%Y%m%d-%H%M%S")-${filename}" \
+    -F "deployment-name=${filename}" \
+    -F "deploy-changed-only=true" \
     -F "file=@${filePath}")
 
   uploadHttpCode=$(echo "$uploadResponse" | tail -n1)


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1443

### Change description ###

- Update deployment name to the name of the file
- deploy-changed-only flag set to true (enable-duplicate-filtering is also set to true with this)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
